### PR TITLE
-c -T -R, leaks, malloc checks

### DIFF
--- a/src/duff.c
+++ b/src/duff.c
@@ -131,6 +131,10 @@ int thorough_flag = 0;
  */
 int ignore_empty_flag = 0;
 
+/* use human readable mode when displayng sizes in header
+ */
+int human_readable_flag = 0;
+
 /* some progress indicators */
 int progress_flag = 0;
 
@@ -169,7 +173,7 @@ static void version(void)
  */
 static void usage(void)
 {
-  printf(_("Usage: %s [-0DHLPacepqrtuz] [-d function] [-f format] [-l size] [file ...]\n"),
+  printf(_("Usage: %s [-0DHLPRTacepqrtuz] [-d function] [-f format] [-l size] [file ...]\n"),
            PACKAGE_NAME);
 
   printf("       %s -h\n", PACKAGE_NAME);
@@ -181,6 +185,7 @@ static void usage(void)
   printf(_("  -H  follow symbolic links to directories on the command line\n"));
   printf(_("  -L  follow all symbolic links to directories\n"));
   printf(_("  -P  do not follow any symbolic links (default)\n"));
+  printf(_("  -R  use human-readable format in cluster header\n"));
   printf(_("  -T  display progress to STDERR\n"));
   printf(_("  -a  include hidden files when searching recursively\n"));
   printf(_("  -d  the message digest function to use: sha1 sha256 sha384 sha512\n"));
@@ -218,7 +223,7 @@ int main(int argc, char** argv)
   bindtextdomain(PACKAGE, LOCALEDIR);
   textdomain(PACKAGE);
 
-  while ((ch = getopt(argc, argv, "0DHLPTacd:ef:hl:pqrtuvz")) != -1)
+  while ((ch = getopt(argc, argv, "0DHLPRTacd:ef:hl:pqrtuvz")) != -1)
   {
     switch (ch)
     {
@@ -236,6 +241,9 @@ int main(int argc, char** argv)
         break;
       case 'P':
         follow_links_mode = NO_SYMLINKS;
+        break;
+      case 'R':
+        human_readable_flag = 1;
         break;
       case 'T':
         progress_flag = 1;
@@ -301,9 +309,19 @@ int main(int argc, char** argv)
   if (!header_format)
   {
     if (thorough_flag)
-      header_format = _("%n files in cluster %i (%s bytes)");
+    {
+      if (human_readable_flag)
+        header_format = _("%n files in cluster %i (size %s)");
+      else
+        header_format = _("%n files in cluster %i (%s bytes)");
+    }
     else
-      header_format = _("%n files in cluster %i (%s bytes, digest %d)");
+    {
+      if (human_readable_flag)
+        header_format = _("%n files in cluster %i (size %s, digest %d)");
+      else
+        header_format = _("%n files in cluster %i (%s bytes, digest %d)");
+    }
   }
 
   header_uses_digest = cluster_header_uses_digest(header_format);

--- a/src/duff.c
+++ b/src/duff.c
@@ -112,6 +112,12 @@ int quiet_flag = 0;
  */
 int physical_flag = 0;
 
+/* Makes the program not consider hard-links to be duplicate files but 
+ * only in case they all point to the same inode. 
+ */
+int physical_cluster_flag = 0;
+
+
 /* For each duplicate cluster, reports all but one.  Useful for uses of
  * `xargs rm'.
  */
@@ -161,7 +167,7 @@ static void version(void)
  */
 static void usage(void)
 {
-  printf(_("Usage: %s [-0DHLPaepqrtuz] [-d function] [-f format] [-l size] [file ...]\n"),
+  printf(_("Usage: %s [-0DHLPacepqrtuz] [-d function] [-f format] [-l size] [file ...]\n"),
            PACKAGE_NAME);
 
   printf("       %s -h\n", PACKAGE_NAME);
@@ -181,6 +187,7 @@ static void usage(void)
   printf(_("  -l  the minimum size that activates sampling\n"));
   printf(_("  -q  quiet; suppress warnings and error messages\n"));
   printf(_("  -p  physical files; do not report multiple hard links as duplicates\n"));
+  printf(_("  -c  report multiple hard links as duplicates only if at least two different physical files exist\n"));
   printf(_("  -r  search recursively through specified directories\n"));
   printf(_("  -t  thorough; force byte-by-byte comparison of files\n"));
   printf(_("  -u  unique mode; list unique files instead of duplicates\n"));
@@ -208,7 +215,7 @@ int main(int argc, char** argv)
   bindtextdomain(PACKAGE, LOCALEDIR);
   textdomain(PACKAGE);
 
-  while ((ch = getopt(argc, argv, "0DHLPad:ef:hl:pqrtuvz")) != -1)
+  while ((ch = getopt(argc, argv, "0DHLPacd:ef:hl:pqrtuvz")) != -1)
   {
     switch (ch)
     {
@@ -253,6 +260,9 @@ int main(int argc, char** argv)
         break;
       case 'p':
         physical_flag = 1;
+        break;
+      case 'c':
+        physical_cluster_flag = 1;
         break;
       case 'q':
         quiet_flag = 1;

--- a/src/duff.c
+++ b/src/duff.c
@@ -117,7 +117,6 @@ int physical_flag = 0;
  */
 int physical_cluster_flag = 0;
 
-
 /* For each duplicate cluster, reports all but one.  Useful for uses of
  * `xargs rm'.
  */
@@ -131,6 +130,9 @@ int thorough_flag = 0;
 /* Makes the program not report files of zero size as duplicates.
  */
 int ignore_empty_flag = 0;
+
+/* some progress indicators */
+int progress_flag = 0;
 
 /* Specifies the look of the cluster header.
  * If set to the empty string, no headers are printed.
@@ -179,6 +181,7 @@ static void usage(void)
   printf(_("  -H  follow symbolic links to directories on the command line\n"));
   printf(_("  -L  follow all symbolic links to directories\n"));
   printf(_("  -P  do not follow any symbolic links (default)\n"));
+  printf(_("  -T  display progress to STDERR\n"));
   printf(_("  -a  include hidden files when searching recursively\n"));
   printf(_("  -d  the message digest function to use: sha1 sha256 sha384 sha512\n"));
   printf(_("  -e  excess mode; list all but one file from each cluster (no headers)\n"));
@@ -215,7 +218,7 @@ int main(int argc, char** argv)
   bindtextdomain(PACKAGE, LOCALEDIR);
   textdomain(PACKAGE);
 
-  while ((ch = getopt(argc, argv, "0DHLPacd:ef:hl:pqrtuvz")) != -1)
+  while ((ch = getopt(argc, argv, "0DHLPTacd:ef:hl:pqrtuvz")) != -1)
   {
     switch (ch)
     {
@@ -233,6 +236,9 @@ int main(int argc, char** argv)
         break;
       case 'P':
         follow_links_mode = NO_SYMLINKS;
+        break;
+      case 'T':
+        progress_flag = 1;
         break;
       case 'a':
         all_files_flag = 1;

--- a/src/duff.h
+++ b/src/duff.h
@@ -146,7 +146,9 @@ void print_cluster_header(const char* format,
                           unsigned int index,
                           off_t size,
                           const uint8_t* digest);
+char* add_thousands_separator(char *a, char *out, size_t out_size);
+char* add_thousands_separator_z(size_t sz, char *out, size_t out_size);
+char* human_readable(size_t size, char *out, size_t out_size);
 
 /* These are defined and documented in duffdriver.c */
 void process_args(int argc, char** argv);
-

--- a/src/duffdriver.c
+++ b/src/duffdriver.c
@@ -376,7 +376,9 @@ static void process_file(const char* path, struct stat* sb)
     if (t > prev_progress_time)
     {
       float td = (float)(t - start_progress_time);
-      fprintf(stderr, "duff phase 1: processed %d files (%.0f files/s)\r", processed_files, processed_files / td);
+      char processed_str[256];
+      fprintf(stderr, "duff phase 1: processed %s files (%.0f files/s)\r",
+        add_thousands_separator_z(processed_files, processed_str, 256), processed_files / td);
       prev_progress_time = t;
     }
   }
@@ -519,8 +521,12 @@ static void process_clusters(void)
 
         if (t > prev_progress_time)
         {
-          fprintf(stderr, "duff phase 2: processed %.0f%% (%zu files out of %zu)\r", 
-            processed_files_b * 100.0 / processed_files, processed_files_b, processed_files);
+          char p_str1[256];
+          char p_str2[256];
+          fprintf(stderr, "duff phase 2: processed %.0f%% (%s files out of %s)\r",
+            processed_files_b * 100.0 / processed_files,
+            add_thousands_separator_z(processed_files_b, p_str1, 256),
+            add_thousands_separator_z(processed_files, p_str2, 256));
           prev_progress_time = t;
         }
       }

--- a/src/duffdriver.c
+++ b/src/duffdriver.c
@@ -546,6 +546,7 @@ static void process_clusters(void)
     {
       free_file(&files[j]);
     }
+    free_file_list(&buckets[i]);
   }
 
   free_file_list(&duplicates);

--- a/src/dufffile.c
+++ b/src/dufffile.c
@@ -181,7 +181,6 @@ static int get_file_sample(File* file)
 
   if (file->status == SAMPLED || file->status == HASHED)
     return 0;
-
   stream = fopen(file->path, "rb");
   if (!stream)
   {
@@ -197,6 +196,8 @@ static int get_file_sample(File* file)
     size = file->size;
 
   sample = malloc(size);
+  if (sample == NULL)
+    error(_("Out of memory"));
 
   if (fread(sample, size, 1, stream) < 1)
   {
@@ -263,11 +264,13 @@ static int get_file_digest(File* file)
 
       update_digest(buffer, size);
     }
-
     fclose(stream);
   }
 
   file->digest = malloc(get_digest_size());
+  if (file->digest == NULL)
+    error(_("Out of memory"));
+
   finish_digest(file->digest);
 
   file->status = HASHED;

--- a/src/duffutil.c
+++ b/src/duffutil.c
@@ -457,3 +457,65 @@ void print_cluster_header(const char* format,
   }
 }
 
+/* shorten given number to 3 digits + qualifier
+ * eg. "12345" -> "12K"
+ * out buffer must be able to hold 3 digits + 1 letter + null
+ */
+char* human_readable(size_t size, char *out, size_t out_size)
+{
+  int i = 0;
+
+  if (out_size < 5)
+  {
+    error(_("human_readable: output buffer too short"));
+  }
+
+  const char* units[] = {"", "K", "M", "G", "T", "P", "E"};
+  while (size >= 1000)
+  {
+    size /= 1024;
+    i++; /* don't care bout more than thousand exabytes */
+  }
+
+  if (size == 0) { size = 1; } /* corner case between 1000 and 1024 */
+
+  snprintf(out, 5, "%d%s", size, units[i]);
+  return out;
+}
+
+/* add thousand separator to integer (as a string)
+ * eg. 1234567 -> 1,234,567
+ *TODO: assert on out_size overflow
+ */
+char* add_thousands_separator(char *a, char *out, size_t out_size)
+{
+  char *comma = ",";
+  char *o = out;
+  int n = 0;
+  int k = strlen(a);
+  int step = k % 3;
+  if (step == 0) step = 3;
+
+  while (k > 3)
+  {
+    strncpy(o, a, step);
+    o += step;
+    strncpy(o, comma, 1);
+    o++;
+    a += step;
+    k -= step;
+    step = 3; /* only in first round it can be smaller */
+  }
+  strncpy(o, a, k);
+  o += k;
+  *o = '\0';
+  return out;
+}
+
+char* add_thousands_separator_z(size_t sz, char *out, size_t out_size)
+{
+    char tmp[out_size];
+    snprintf(tmp, out_size, "%zu", sz);
+    return add_thousands_separator(tmp, out, out_size);
+}
+

--- a/src/duffutil.c
+++ b/src/duffutil.c
@@ -71,6 +71,7 @@
 /* These flags are defined and documented in duff.c.
  */
 extern int null_terminate_flag;
+extern int human_readable_flag;
 
 /* Message digest functions.
  */
@@ -420,13 +421,31 @@ void print_cluster_header(const char* format,
       switch (*c)
       {
         case 's':
-          printf("%" PRIi64, size);
+          if (human_readable_flag)
+          {
+            char buf[5];
+            human_readable(size, buf, 5);
+            fputs(buf, stdout); fputs("B", stdout);
+          }
+          else
+          {
+            printf("%" PRIi64, size);
+          }
           break;
         case 'i':
           printf("%u", index);
           break;
         case 'n':
-          printf("%u", count);
+          if (human_readable_flag)
+          {
+            char buf[256]; /* probably overkil, would anybody have cluster of more than 999 duplicates? */
+            add_thousands_separator_z((size_t)count, buf, 256);
+            fputs(buf, stdout);
+          }
+          else
+          {
+            printf("%u", count);
+          }
           break;
         case 'c':
         case 'd':


### PR DESCRIPTION
several changes included, unfortunately with old indent (happy to see you switching to 4-spaces).

I don't know is use-case for -c is clear (I'm trying to make an example for man-page, I not commited yet though). I have  a script similar to join-duplicates.sh (in perl) but using this -c mode - before I had problems with case with two (or more) groups or hardlinks, eg. 5 file entries, all the same content, hardlinked in groups like:
inode / name:
100 / a.txt
100 / b.txt
200 / c.txt
200 / d.txt
200 / e.txt
and with -p mode duff reported duplicate group of
a.txt
c.txt
- after merge I had
  100 / a.txt
  100 / b.txt
  100 / c.txt
  200 / d.txt
  200 / e.txt

in next run it was not impossible to get from duff -p following list:
d.txt
a.txt
and after merge I had
200 / a.txt
100 / b.txt
100 / c.txt
200 / d.txt
200 / e.txt

and so on... never ending story.
Alternatively I could run duff without -p but it causes reporting all the properly hardlinked groups - not fun either. So -c fixes the case :)

I'll try to update the man page during weekend. Feel free to ask about the changes I made - I'd love to see them in duff ;)
